### PR TITLE
Improved `MenuBar` buttons accessibility

### DIFF
--- a/src/js/ui/MenuBar.js
+++ b/src/js/ui/MenuBar.js
@@ -131,11 +131,14 @@ export class MenuBar {
 			this._el.container.setAttribute("ontouchstart"," ");
 		}
 
-		this._el.button_backtostart.innerHTML		= "<span class='tl-icon-goback'></span>";
-		this._el.button_zoomin.innerHTML			= "<span class='tl-icon-zoom-in'></span>";
-		this._el.button_zoomout.innerHTML			= "<span class='tl-icon-zoom-out'></span>";
+		this._el.button_backtostart.innerHTML = "<span class='tl-icon-goback'></span>";
+        this._el.button_backtostart.setAttribute('aria-label', 'Back to start');
 
+		this._el.button_zoomin.innerHTML = "<span class='tl-icon-zoom-in'></span>";
+        this._el.button_zoomin.setAttribute('aria-label', 'Zoom in');
 
+		this._el.button_zoomout.innerHTML = "<span class='tl-icon-zoom-out'></span>";
+        this._el.button_zoomout.setAttribute('aria-label', 'Zoom out');
 	}
 
 	_initEvents () {

--- a/src/js/ui/MenuBar.js
+++ b/src/js/ui/MenuBar.js
@@ -67,19 +67,19 @@ export class MenuBar {
 	}
 
 	toogleZoomIn(show) {
-		if (show) {
-      removeClass(this._el.button_zoomin,'tl-menubar-button-inactive');
-		} else {
-      addClass(this._el.button_zoomin,'tl-menubar-button-inactive');
-		}
+        if (show) {
+            this._el.button_zoomin.removeAttribute('disabled');
+        } else {
+            this._el.button_zoomin.setAttribute('disabled', true);
+        }
 	}
 
 	toogleZoomOut(show) {
-		if (show) {
-      removeClass(this._el.button_zoomout,'tl-menubar-button-inactive');
-		} else {
-      addClass(this._el.button_zoomout,'tl-menubar-button-inactive');
-		}
+        if (show) {
+            this._el.button_zoomout.removeAttribute('disabled');
+        } else {
+            this._el.button_zoomout.setAttribute('disabled', true);
+        }
 	}
 
 	setSticky(y) {

--- a/src/js/ui/MenuBar.js
+++ b/src/js/ui/MenuBar.js
@@ -123,9 +123,9 @@ export class MenuBar {
 	_initLayout () {
 
 		// Create Layout
-		this._el.button_zoomin = DOM.create('span', 'tl-menubar-button', this._el.container);
-		this._el.button_zoomout = DOM.create('span', 'tl-menubar-button', this._el.container);
-		this._el.button_backtostart = DOM.create('span', 'tl-menubar-button', this._el.container);
+		this._el.button_zoomin = DOM.create('button', 'tl-menubar-button', this._el.container);
+		this._el.button_zoomout = DOM.create('button', 'tl-menubar-button', this._el.container);
+		this._el.button_backtostart = DOM.create('button', 'tl-menubar-button', this._el.container);
 
 		if (Browser.mobile) {
 			this._el.container.setAttribute("ontouchstart"," ");

--- a/src/less/ui/TL.MenuBar.Button.less
+++ b/src/less/ui/TL.MenuBar.Button.less
@@ -19,13 +19,14 @@
 
 	}
 
-	&[disabled] {
+	&:disabled {
 		opacity:0.33;
+        cursor:default;
 	}
 	&:hover, &:focus-visible {
 		background:@color-foreground;
 		color:@color-background;
-		&[disabled] {
+		&:disabled {
 			color:darken(@marker-color,15);
 			background-color:fadeout(@ui-background-color, 10%);
 		}

--- a/src/less/ui/TL.MenuBar.Button.less
+++ b/src/less/ui/TL.MenuBar.Button.less
@@ -19,13 +19,13 @@
 
 	}
 
-	&.tl-menubar-button-inactive {
+	&[disabled] {
 		opacity:0.33;
 	}
 	&:hover, &:focus-visible {
 		background:@color-foreground;
 		color:@color-background;
-		&.tl-menubar-button-inactive {
+		&[disabled] {
 			color:darken(@marker-color,15);
 			background-color:fadeout(@ui-background-color, 10%);
 		}

--- a/src/less/ui/TL.MenuBar.Button.less
+++ b/src/less/ui/TL.MenuBar.Button.less
@@ -3,6 +3,7 @@
 
 .tl-menubar-button {
 	//border-left: 1px solid darken(@color-background,10);
+    border:none;
 	font-size: 18px;
 	line-height:18px;
 	//padding: 6px 12px 6px 12px;
@@ -15,13 +16,13 @@
 	//color:@color-text;
 	color:@marker-color-menubar-button;
 	[class^="tl-icon-"], [class*=" tl-icon-"] {
-		
+
 	}
-	
+
 	&.tl-menubar-button-inactive {
 		opacity:0.33;
 	}
-	&:hover {
+	&:hover, &:focus-visible {
 		background:@color-foreground;
 		color:@color-background;
 		&.tl-menubar-button-inactive {


### PR DESCRIPTION
## This PR fulfills the issue - https://github.com/NUKnightLab/TimelineJS3/issues/757

Transformed the generic `span` element for the button into a semantic `button` element, but preserved the original styles.
Also added an alternative text which describes the buttons' intentions.

Demo with the screenreader on:

https://user-images.githubusercontent.com/68850090/174763999-06c9bca0-e555-45b5-bf98-bb01509ba0c1.mp4


