### PR TITLE
Splitted `Timeline` component into aria regions

### DIFF
--- a/src/js/timeline/Timeline.js
+++ b/src/js/timeline/Timeline.js
@@ -194,6 +194,8 @@ class Timeline {
         // Apply base class to container
         addClass(this._el.container, 'tl-timeline');
         this._el.container.setAttribute('tabindex', '0');
+        this._el.container.setAttribute('role', 'region');
+        this._el.container.setAttribute('aria-role', 'Timeline');
 
         if (this.options.is_embed) {
             addClass(this._el.container, 'tl-timeline-embed');
@@ -426,6 +428,8 @@ class Timeline {
 
         // Create TimeNav
         this._timenav = new TimeNav(this._el.timenav, this.config, this.options, this.language);
+        this._el.timenav.setAttribute('role', 'group');
+        this._el.timenav.setAttribute('aria-role', 'Timeline navigation');
         this._timenav.on('loaded', this._onTimeNavLoaded, this);
         this._timenav.options.height = this.options.timenav_height;
         this._timenav.init();
@@ -438,6 +442,8 @@ class Timeline {
 
         // Create StorySlider
         this._storyslider = new StorySlider(this._el.storyslider, this.config, this.options, this.language);
+        this._el.storyslider.setAttribute('role', 'group');
+        this._el.storyslider.setAttribute('aria-label', 'Timeline content');
         this._storyslider.on('loaded', this._onStorySliderLoaded, this);
         this._storyslider.init();
 


### PR DESCRIPTION
## This PR fulfills the issue - https://github.com/NUKnightLab/TimelineJS3/issues/757 + https://github.com/NUKnightLab/TimelineJS3/issues/753

Placed the entire Timeline in an element with `role=”region”` and `aria-label=”Timeline”`. Moreover, broke down elements into 2 groups 
`role=”group”` `aria-label=”Timeline Content”`  (previous, next, and the slide content)
&
`role=”group”` `aria-label=”Timeline Controls”` (everything in the lower part of the timeline)




