### PR TITLE
Added alternative text for the `Slide` background image

### DIFF
--- a/src/js/slider/Slide.js
+++ b/src/js/slider/Slide.js
@@ -263,6 +263,10 @@ export class Slide {
                     this.has.background.color_value = "#000";
                     this._el.background.style.display = "block";
                 }
+                if (this.data.background.alt) {
+                    this._el.background.setAttribute('role', 'img');
+                    this._el.background.setAttribute('aria-label', this.data.background.alt);
+                }
             }
             if (this.data.background.color) {
                 this.has.background.color = true;

--- a/website/templates/docs/json-format.html
+++ b/website/templates/docs/json-format.html
@@ -159,6 +159,7 @@
         <div class="column-8">
           A Javascript object. The object can have these properties:
           <br/><code>url</code>: the fully-qualified URL pointing to an image which will be used as the background
+          <br/><code>alt</code>: alternative text that describes the image provided by the <code>url</code> property
           <br/><code>color</code>: a CSS color, in hexadecimal (e.g. <code>#0f9bd1</code>) or a valid <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#Color_keywords">CSS color keyword</a>.
         </div>
 


### PR DESCRIPTION
## This PR fulfills the issue - https://github.com/NUKnightLab/TimelineJS3/issues/761

Added the new `alt` configuration property for the `background`. Also described it in the JSON documentation

