### PR TITLE
Allowed access the points of the `Timeline` while not changing slides

### DIFF
--- a/src/js/timeline/Timeline.js
+++ b/src/js/timeline/Timeline.js
@@ -406,13 +406,13 @@ class Timeline {
 
         // Create Layout
         if (this.options.timenav_position == "top") {
-            this._el.menubar = DOM.create('div', 'tl-menubar', this._el.container);
             this._el.timenav = DOM.create('div', 'tl-timenav', this._el.container);
+            this._el.menubar = DOM.create('div', 'tl-menubar', this._el.container);
             this._el.storyslider = DOM.create('div', 'tl-storyslider', this._el.container);
         } else {
             this._el.storyslider = DOM.create('div', 'tl-storyslider', this._el.container);
-            this._el.menubar = DOM.create('div', 'tl-menubar', this._el.container);
             this._el.timenav = DOM.create('div', 'tl-timenav', this._el.container);
+            this._el.menubar = DOM.create('div', 'tl-menubar', this._el.container);
         }
 
         // Knight Lab Logo

--- a/src/js/timenav/TimeMarker.js
+++ b/src/js/timenav/TimeMarker.js
@@ -226,6 +226,12 @@ export class TimeMarker {
 		this.fire("markerclick", { unique_id: this.data.unique_id });
 	}
 
+    _onMarkerKeydown(e) {
+        if (/Space|Enter/.test(e.code)) {
+            this.fire("markerclick", { unique_id: this.data.unique_id });
+        }
+    }
+
     _onMarkerBlur(e) {
         this.fire("markerblur", { unique_id: this.data.unique_id });
     }
@@ -296,6 +302,7 @@ export class TimeMarker {
 
 	_initEvents() {
 		DOMEvent.addListener(this._el.container, 'click', this._onMarkerClick, this);
+        DOMEvent.addListener(this._el.container, 'keydown', this._onMarkerKeydown, this);
         DOMEvent.addListener(this._el.container, 'blur', this._onMarkerBlur, this);
 	}
 

--- a/src/js/timenav/TimeMarker.js
+++ b/src/js/timenav/TimeMarker.js
@@ -109,6 +109,10 @@ export class TimeMarker {
 		}
 	}
 
+    setFocus(options = { preventScroll: true }) {
+        this._el.container.focus(options);
+    }
+
 	addTo(container) {
 		container.appendChild(this._el.container);
 	}

--- a/src/js/timenav/TimeMarker.js
+++ b/src/js/timenav/TimeMarker.js
@@ -227,6 +227,8 @@ export class TimeMarker {
 	_initLayout() {
 		// Create Layout
 		this._el.container = DOM.create("div", "tl-timemarker");
+        this._el.container.setAttribute('tabindex', '-1');
+
 		if (this.data.unique_id) {
 			this._el.container.id = this.data.unique_id + "-marker";
 		}

--- a/src/js/timenav/TimeMarker.js
+++ b/src/js/timenav/TimeMarker.js
@@ -226,6 +226,10 @@ export class TimeMarker {
 		this.fire("markerclick", { unique_id: this.data.unique_id });
 	}
 
+    _onMarkerBlur(e) {
+        this.fire("markerblur", { unique_id: this.data.unique_id });
+    }
+
 	/*	Private Methods
 	================================================== */
 	_initLayout() {
@@ -292,6 +296,7 @@ export class TimeMarker {
 
 	_initEvents() {
 		DOMEvent.addListener(this._el.container, 'click', this._onMarkerClick, this);
+        DOMEvent.addListener(this._el.container, 'blur', this._onMarkerBlur, this);
 	}
 
 	// Update Display

--- a/src/js/timenav/TimeNav.js
+++ b/src/js/timenav/TimeNav.js
@@ -624,20 +624,20 @@ export class TimeNav {
         switch (e.key) {
             case "ArrowUp":
             case "ArrowRight": {
-                console.log('Next item');
+                this.focusNext();
                 break;
             }
             case "ArrowDown":
             case "ArrowLeft": {
-                console.log("Prev item");
+                this.focusPrevious();
                 break;
             }
             case "Home":{
-                console.log('First item');
+                this.focusOn(0);
                 break;
             }
             case "End":{
-                console.log('Last item');
+                this.focusOn(this._markers.length - 1);
                 break;
             }
         }

--- a/src/js/timenav/TimeNav.js
+++ b/src/js/timenav/TimeNav.js
@@ -576,6 +576,31 @@ export class TimeNav {
 
     }
 
+    _onKeydown(e) {
+        DOMEvent.stopPropagation(e);
+
+        switch (e.key) {
+            case "ArrowUp":
+            case "ArrowRight": {
+                console.log('Next item');
+                break;
+            }
+            case "ArrowDown":
+            case "ArrowLeft": {
+                console.log("Prev item");
+                break;
+            }
+            case "Home":{
+                console.log('First item');
+                break;
+            }
+            case "End":{
+                console.log('Last item');
+                break;
+            }
+        }
+    }
+
     /*	Private Methods
     ================================================== */
 
@@ -667,6 +692,7 @@ export class TimeNav {
         // Scroll Events
         DOMEvent.addListener(this._el.container, 'mousewheel', this._onMouseScroll, this);
         DOMEvent.addListener(this._el.container, 'DOMMouseScroll', this._onMouseScroll, this);
+        DOMEvent.addListener(this._el.container, 'keydown', this._onKeydown, this);
     }
 
     _initData() {

--- a/src/js/timenav/TimeNav.js
+++ b/src/js/timenav/TimeNav.js
@@ -39,6 +39,7 @@ export class TimeNav {
         } else {
             this._el.container = DOM.get(elem);
         }
+        this._el.container.setAttribute('tabindex', '0');
 
         this.config = timeline_config;
 

--- a/src/js/timenav/TimeNav.js
+++ b/src/js/timenav/TimeNav.js
@@ -365,7 +365,7 @@ export class TimeNav {
     _resetMarkersActive() {
         for (var i = 0; i < this._markers.length; i++) {
             this._markers[i].setActive(false);
-        };
+        }
     }
 
     _findMarkerIndex(n) {
@@ -459,28 +459,8 @@ export class TimeNav {
         if (n >= 0 && n < this._markers.length) {
             this._markers[n].setActive(true);
         }
-        // Stop animation
-        if (this.animator) {
-            this.animator.stop();
-        }
 
-        if (fast) {
-            this._el.slider.className = "tl-timenav-slider";
-            this._el.slider.style.left = -this._markers[_n].getLeft() + (this.options.width / 2) + "px";
-        } else {
-            if (css_animation) {
-                this._el.slider.className = "tl-timenav-slider tl-timenav-slider-animate";
-                this.animate_css = true;
-                this._el.slider.style.left = -this._markers[_n].getLeft() + (this.options.width / 2) + "px";
-            } else {
-                this._el.slider.className = "tl-timenav-slider";
-                this.animator = Animate(this._el.slider, {
-                    left: -this._markers[_n].getLeft() + (this.options.width / 2) + "px",
-                    duration: _duration,
-                    easing: _ease
-                });
-            }
-        }
+        this.animateMovement(_n, fast, css_animation, _duration, _ease);
 
         if (n >= 0 && n < this._markers.length) {
             this.current_id = this._markers[n].data.unique_id;
@@ -491,6 +471,35 @@ export class TimeNav {
 
     goToId(id, fast, css_animation) {
         this.goTo(this._findMarkerIndex(id), fast, css_animation);
+    }
+
+
+    animateMovement(n, fast, css_animation, duration, ease) {
+        // Stop animation
+        if (this.animator) {
+            this.animator.stop();
+        }
+
+        if (fast) {
+            this._el.slider.className = "tl-timenav-slider";
+            this._el.slider.style.left = -this._markers[n].getLeft() +
+                (this.options.width / 2) + "px";
+        } else {
+            if (css_animation) {
+                this._el.slider.className = "tl-timenav-slider tl-timenav-slider-animate";
+                this.animate_css = true;
+                this._el.slider.style.left = -this._markers[n].getLeft() +
+                    (this.options.width / 2) + "px";
+            } else {
+                this._el.slider.className = "tl-timenav-slider";
+                this.animator = Animate(this._el.slider, {
+                    left: -this._markers[n].getLeft() +
+                        (this.options.width / 2) + "px",
+                    duration: duration,
+                    easing: ease
+                });
+            }
+        }
     }
 
     /*	Events

--- a/src/js/timenav/TimeNav.js
+++ b/src/js/timenav/TimeNav.js
@@ -81,6 +81,9 @@ export class TimeNav {
         // Current Marker
         this.current_id = "";
 
+        // Current Focused Marker
+        this.current_focused_id = "";
+
         // TimeScale
         this.timescale = {};
 
@@ -463,9 +466,9 @@ export class TimeNav {
         this.animateMovement(_n, fast, css_animation, _duration, _ease);
 
         if (n >= 0 && n < this._markers.length) {
-            this.current_id = this._markers[n].data.unique_id;
+            this.current_id = this.current_focused_id = this._markers[n].data.unique_id;
         } else {
-            this.current_id = '';
+            this.current_id = this.current_focused_id = '';
         }
     }
 
@@ -473,6 +476,36 @@ export class TimeNav {
         this.goTo(this._findMarkerIndex(id), fast, css_animation);
     }
 
+    focusOn(n, fast, css_animation) {
+        const _ease = this.options.ease,
+            _duration = this.options.duration,
+            _n = (n < 0) ? 0 : n;
+
+        this.animateMovement(_n, fast, css_animation, _duration, _ease);
+
+        if (n >= 0 && n < this._markers.length) {
+            this._markers[n].setFocus();
+            this.current_focused_id = this._markers[n].data.unique_id;
+        }
+    }
+
+    focusNext() {
+        const n = this._findMarkerIndex(this.current_focused_id);
+        if ((n + 1) < this._markers.length) {
+            this.focusOn(n + 1);
+        } else {
+            this.focusOn(n);
+        }
+    }
+
+    focusPrevious() {
+        const n = this._findMarkerIndex(this.current_focused_id);
+        if (n - 1 >= 0) {
+            this.focusOn(n - 1);
+        } else {
+            this.focusOn(n);
+        }
+    }
 
     animateMovement(n, fast, css_animation, duration, ease) {
         // Stop animation

--- a/src/js/timenav/TimeNav.js
+++ b/src/js/timenav/TimeNav.js
@@ -371,6 +371,12 @@ export class TimeNav {
         }
     }
 
+    _resetMarkersBlurListeners() {
+        for (var i = 0; i < this._markers.length; i++) {
+            this._markers[i].off('markerblur', this._onMarkerBlur, this);
+        }
+    }
+
     _findMarkerIndex(n) {
         var _n = -1;
         if (typeof n == 'string' || n instanceof String) {
@@ -483,9 +489,11 @@ export class TimeNav {
 
         this.animateMovement(_n, fast, css_animation, _duration, _ease);
 
+        this._resetMarkersBlurListeners();
         if (n >= 0 && n < this._markers.length) {
             this._markers[n].setFocus();
             this.current_focused_id = this._markers[n].data.unique_id;
+            this._markers[n].on('markerblur', this._onMarkerBlur, this);
         }
     }
 
@@ -558,6 +566,12 @@ export class TimeNav {
         // Go to the clicked marker
         this.goToId(e.unique_id);
         this.fire("change", { unique_id: e.unique_id });
+    }
+
+    _onMarkerBlur(e) {
+        // Reset the focused marked to the active marker after it lost the focus
+        if (this.current_focused_id === this.current_id) return;
+        this.focusOn(this._findMarkerIndex(this.current_id));
     }
 
     _onMouseScroll(e) {

--- a/src/js/timenav/TimeNav.js
+++ b/src/js/timenav/TimeNav.js
@@ -41,6 +41,13 @@ export class TimeNav {
         }
         this._el.container.setAttribute('tabindex', '0');
 
+        // Prevents the unwanted keyboard handling by the screen readers
+        this._el.container.setAttribute('role', 'application');
+        this._el.container.setAttribute('aria-label', 'Timeline navigation');
+        this._el.container.setAttribute('aria-description',
+            'Navigate between markers with arrow keys. Press "Home" for the first and "End" for the last markers'
+        );
+
         this.config = timeline_config;
 
         //Options

--- a/src/js/timenav/TimeNav.js
+++ b/src/js/timenav/TimeNav.js
@@ -41,7 +41,7 @@ export class TimeNav {
         }
         this._el.container.setAttribute('tabindex', '0');
 
-        // Prevents the unwanted keyboard handling by the screen readers
+        // Prevents inconsistent default keyboard handling by the screen readers
         this._el.container.setAttribute('role', 'application');
         this._el.container.setAttribute('aria-label', 'Timeline navigation');
         this._el.container.setAttribute('aria-description',

--- a/src/less/timenav/TL.TimeMarker.less
+++ b/src/less/timenav/TL.TimeMarker.less
@@ -232,10 +232,10 @@
 
 		
 	}
-	
-	/* Hover State
+
+	/* Hover | Focus State
 	================================================== */
-	&:hover {
+	&:hover, &:focus {
 		
 		.tl-timemarker-timespan {
 			background-color: fadeout(@marker-text-color, 85%);
@@ -303,9 +303,9 @@
 		
 	}
 	
-	/* Hover Active State
+	/* Hover | Focus Active State
 	================================================== */
-	&:hover {
+	&:hover, &:focus {
 		&.tl-timemarker-active {
 			.tl-timemarker-content-container {
 				.tl-timemarker-content {
@@ -334,6 +334,12 @@
 			}
 		}
 	}
+
+    /* Focus-visible State
+    ================================================== */
+    &:focus-visible {
+        outline: none;
+    }
 	
 	/* Active Markers
 	================================================== */


### PR DESCRIPTION
## This PR fulfills the issue - https://github.com/NUKnightLab/TimelineJS3/issues/763

### Before approaching this PR, some previous PRs need to be reviewed and merged first - https://github.com/NUKnightLab/TimelineJS3/pull/764
---

Added tab stop that encompasses the `TimeNav` component with all the `TimeMarker`s inside. Added methods that handle the keyboard _arrows_, _home_, and _end_ buttons presses and then focus a user on an according `Marker`. It allows navigating between the markers without switching the currently displayed `Slide`.

Also, I added handling for the case when the user loses focus on the previously navigated `Marker` so then the focus will be restored on the currently selected item.

https://user-images.githubusercontent.com/68850090/174813260-a01c69a7-05eb-4743-b6e0-8cdf3257796a.mp4