### PR TITLE
Improved `TimeMarker` elements accessibility

### DIFF
--- a/src/js/timenav/TimeMarker.js
+++ b/src/js/timenav/TimeMarker.js
@@ -75,6 +75,9 @@ export class TimeMarker {
 		// End date
 		this.has_end_date = false;
 
+        // Alternative text
+        this.ariaLabel = '';
+
 		// Merge Data and Options
 		mergeData(this.options, options);
 		mergeData(this.data, data);
@@ -107,6 +110,13 @@ export class TimeMarker {
 		} else {
 			this._el.container.className = 'tl-timemarker';
 		}
+
+        this._el.container.ariaLabel = this.ariaLabel;
+        if (this.active) {
+            this._el.container.ariaLabel += ', shown';
+        } else {
+            this._el.container.ariaLabel += ', press space to show';
+        }
 	}
 
     setFocus(options = { preventScroll: true }) {
@@ -293,7 +303,7 @@ export class TimeMarker {
 			this._text.innerHTML = unlinkify(this.data.media.caption);
 		}
 
-
+        this.ariaLabel = this._text.innerHTML;
 
 		// Fire event that the slide is loaded
 		this.onLoaded();

--- a/src/js/timenav/TimeMarker.js
+++ b/src/js/timenav/TimeMarker.js
@@ -1,4 +1,4 @@
-import { classMixin, mergeData, unlinkify } from "../core/Util"
+import { classMixin, mergeData, trim, unlinkify } from "../core/Util"
 import Events from "../core/Events"
 import { DOMMixins } from "../dom/DOMMixins"
 import { DOMEvent } from "../dom/DOMEvent"
@@ -9,6 +9,7 @@ import { webkit as BROWSER_WEBKIT } from "../core/Browser";
 import { easeInSpline } from "../animation/Ease";
 
 import { lookupMediaType } from "../media/MediaType"
+import { I18NMixins } from "../language/I18NMixins";
 
 export class TimeMarker {
 	constructor(data, options) {
@@ -230,6 +231,21 @@ export class TimeMarker {
 		this._el.timespan.style.height = remainder + "px";
 	}
 
+    getFormattedDate() {
+        if (trim(this.data.display_date).length > 0) {
+            return this.data.display_date;
+        }
+
+        let date_text = "";
+        if (this.data.end_date) {
+            date_text = " to " + this.data.end_date.getDisplayDate(this.getLanguage());
+        }
+        if (this.data.start_date) {
+            date_text = (date_text ? "from " : "") + this.data.start_date.getDisplayDate(this.getLanguage()) + date_text;
+        }
+        return date_text;
+    }
+
 	/*	Events
 	================================================== */
 	_onMarkerClick(e) {
@@ -303,7 +319,8 @@ export class TimeMarker {
 			this._text.innerHTML = unlinkify(this.data.media.caption);
 		}
 
-        this.ariaLabel = this._text.innerHTML;
+        const date = this.getFormattedDate();
+        this.ariaLabel = `${this._text.innerHTML}, ${date}`;
 
 		// Fire event that the slide is loaded
 		this.onLoaded();
@@ -332,4 +349,4 @@ export class TimeMarker {
 }
 
 
-classMixin(TimeMarker, Events, DOMMixins)
+classMixin(TimeMarker, I18NMixins, Events, DOMMixins)

--- a/src/js/timenav/TimeNav.js
+++ b/src/js/timenav/TimeNav.js
@@ -483,6 +483,8 @@ export class TimeNav {
         } else {
             this.current_id = this.current_focused_id = '';
         }
+
+        this._setLabelWithCurrentMarker();
     }
 
     goToId(id, fast, css_animation) {
@@ -721,6 +723,13 @@ export class TimeNav {
 
     }
 
+    _setLabelWithCurrentMarker() {
+        const currentMarker = this._markers[this._findMarkerIndex(this.current_focused_id)];
+        const currentMarkerText = currentMarker && currentMarker.ariaLabel
+            ? `, ${currentMarker.ariaLabel}, shown`
+            : '';
+        this._el.container.setAttribute('aria-label', `Timeline navigation ${currentMarkerText}`);
+    }
 
     /*	Init
     ================================================== */


### PR DESCRIPTION
## This PR fulfills the issue - https://github.com/NUKnightLab/TimelineJS3/issues/767

### Before approaching this PR, some previous PRs need to be reviewed and merged first - https://github.com/NUKnightLab/TimelineJS3/pull/766
---

Added `aria-label` for each of the `TimeMarker`s that depends on if it's active or not. If the marker is active, the `aria-label` will say `[<event_name>, <event_date>, shown]`, and if it's not active, `[<event_name>, <event_date>, press space to show]`:

https://user-images.githubusercontent.com/68850090/174832977-a19ba396-5860-4718-a6fd-c363b8f4460d.mp4

Moreover, when we land on the `TimeNav` tab stop, it will announce what marker is currently shown:

https://user-images.githubusercontent.com/68850090/174833060-8cae886a-b73f-4a02-87b4-1a2045eb3f34.mp4
