### PR TITLE
Provided state-based `aria-label`s for the `MenuBar` buttons

### DIFF
--- a/src/js/dom/DOMUtil.js
+++ b/src/js/dom/DOMUtil.js
@@ -23,3 +23,13 @@ export function removeClass(el, name) {
 		return w;
 	}).replace(/^\s+/, '');
 }
+
+export function isInViewport(element) {
+    const rect = element.getBoundingClientRect();
+    return (
+        rect.top >= 0 &&
+        rect.left >= 0 &&
+        rect.bottom <= (window.innerHeight || document.documentElement.clientHeight) &&
+        rect.right <= (window.innerWidth || document.documentElement.clientWidth)
+    );
+}

--- a/src/js/timeline/Timeline.js
+++ b/src/js/timeline/Timeline.js
@@ -460,6 +460,7 @@ class Timeline {
         // TimeNav Events
         this._timenav.on('change', this._onTimeNavChange, this);
         this._timenav.on('zoomtoggle', this._onZoomToggle, this);
+        this._timenav.on('visible_ticks_change', this._onVisibleTicksChange, this);
 
         // StorySlider Events
         this._storyslider.on('change', this._onSlideChange, this);
@@ -510,6 +511,10 @@ class Timeline {
         if (this.options.hash_bookmark && this.current_id) {
             this._updateHashBookmark(this.current_id);
         }
+    }
+
+    _onVisibleTicksChange(e) {
+        this._menubar.changeVisibleTicks(e.visible_ticks);
     }
 
     _onBackToStart(e) {

--- a/src/js/timenav/TimeAxis.js
+++ b/src/js/timenav/TimeAxis.js
@@ -1,6 +1,7 @@
 import { classMixin, mergeData } from "../core/Util"
 import Events from "../core/Events"
 import { DOMMixins } from "../dom/DOMMixins"
+import { isInViewport } from "../dom/DOMUtil"
 import { I18NMixins } from "../language/I18NMixins"
 import { easeInSpline } from "../animation/Ease";
 import * as DOM from "../dom/DOM"
@@ -216,8 +217,19 @@ export class TimeAxis {
                     tick.tick.className = "tl-timeaxis-tick";
                 }
 
-            };
+            }
         }
+    }
+
+    getVisibleTicks() {
+        return {
+            major: this._getVisibleTickArray(this.major_ticks),
+            minor: this._getVisibleTickArray(this.minor_ticks)
+        }
+    }
+
+    _getVisibleTickArray(tick_array) {
+        return tick_array.filter(({ tick }) => isInViewport(tick))
     }
 
     /*	Events

--- a/src/js/timenav/TimeNav.js
+++ b/src/js/timenav/TimeNav.js
@@ -487,10 +487,27 @@ export class TimeNav {
         } else {
             this.current_id = '';
         }
+
+        this._dispatchVisibleTicksChange();
     }
 
     goToId(id, fast, css_animation) {
         this.goTo(this._findMarkerIndex(id), fast, css_animation);
+    }
+
+    _dispatchVisibleTicksChange() {
+        /**
+         * The timeout is required to wait till the end of the animation
+         * and repositioning of the ticks on the screen
+         */
+        if(this.ticks_change_timeout) {
+            clearTimeout(this.ticks_change_timeout);
+            this.ticks_change_timeout = null;
+        }
+        this.ticks_change_timeout = setTimeout(() => {
+            const visible_ticks = this.timeaxis.getVisibleTicks();
+            this.fire("visible_ticks_change", { visible_ticks });
+        }, this.options.duration);
     }
 
     /*	Events

--- a/src/js/ui/MenuBar.js
+++ b/src/js/ui/MenuBar.js
@@ -4,7 +4,6 @@ import Events from "../core/Events";
 import { DOMMixins } from "../dom/DOMMixins"
 import { easeInOutQuint } from "../animation/Ease"
 import { classMixin, mergeData } from "../core/Util"
-import { addClass, removeClass } from "../dom/DOMUtil"
 import { DOMEvent } from "../dom/DOMEvent"
 
 export class MenuBar {
@@ -33,6 +32,11 @@ export class MenuBar {
 		if (parent_elem) {
 			this._el.parent = parent_elem;
 		}
+
+        // Data
+        this.data = {
+            visible_ticks_dates: {}
+        }
 
 		//Options
 		this.options = {
@@ -81,6 +85,25 @@ export class MenuBar {
             this._el.button_zoomout.setAttribute('disabled', true);
         }
 	}
+
+    changeVisibleTicks(visible_ticks) {
+        const minor_ticks = visible_ticks.minor;
+
+        const firstTick = minor_ticks[0];
+        const firstYear = this._getTickYear(firstTick);
+
+        const lastTick = minor_ticks[minor_ticks.length - 1];
+        const lastYear = this._getTickYear(lastTick);
+
+        this.data.visible_ticks_dates = {
+            start: firstYear,
+            end: lastYear
+        };
+    }
+
+    _getTickYear(tick) {
+        return tick.date.data.date_obj.getFullYear();
+    }
 
 	setSticky(y) {
 		this.options.menubar_default_y = y;

--- a/src/js/ui/MenuBar.js
+++ b/src/js/ui/MenuBar.js
@@ -99,6 +99,8 @@ export class MenuBar {
             start: firstYear,
             end: lastYear
         };
+
+        this._updateZoomAriaLabels()
     }
 
     _getTickYear(tick) {
@@ -125,6 +127,10 @@ export class MenuBar {
 		this._updateDisplay(w, h, a, l);
 	}
 
+    getFormattedTimespan() {
+        const { start, end } = this.data.visible_ticks_dates;
+        return start && end ? `than ${start} to ${end}` : "";
+    }
 
 	/*	Events
 	================================================== */
@@ -181,6 +187,18 @@ export class MenuBar {
 		}
 	}
 
+    // Update Display
+    _updateZoomAriaLabels() {
+        const timespan = this.getFormattedTimespan();
+        if (!timespan) {
+            this._el.button_zoomin.setAttribute('aria-description', '');
+            this._el.button_zoomout.setAttribute('aria-description', '');
+            return;
+        }
+
+        this._el.button_zoomin.setAttribute('aria-description', `Show less ${timespan}`);
+        this._el.button_zoomout.setAttribute('aria-description', `Show more ${timespan}`);
+    }
 }
 
 classMixin(MenuBar, DOMMixins, Events)


### PR DESCRIPTION
## This PR fulfills the issue - https://github.com/NUKnightLab/TimelineJS3/issues/769

### Before approaching this PR, some previous PRs need to be reviewed and merged first - https://github.com/NUKnightLab/TimelineJS3/pull/758
---

Added dynamic tracking on what minor ticks are currently displayed on the screen to provide more data to the alternative text of the zoom-in/out buttons:
- _“zoom in, to show less than `<minor_start>` to `<minor_end>`”_ e.g. (_“... less than 1783 to 1823”_)
- _“zoom out, to show more than `<minor_start>` to `<minor_end>`”_ (_“... more than 1783 to 1823”_)

https://user-images.githubusercontent.com/68850090/174852479-0bcc3b9b-55ca-42c0-b059-6cc6b2217542.mp4