### PR TITLE
Fixed exception on click on the left/right arrow on first/last slide

### DIFF
--- a/src/js/timeline/Timeline.js
+++ b/src/js/timeline/Timeline.js
@@ -833,8 +833,12 @@ class Timeline {
 
     // Goto slide n
     goTo(n) {
+        if (n < 0 || n >= this.config.events.length) {
+            return;
+        }
+
         if (this.config.title) {
-            if (n == 0) {
+            if (n === 0) {
                 this.goToId(this.config.title.unique_id);
             } else {
                 this.goToId(this.config.events[n - 1].unique_id);


### PR DESCRIPTION
## This PR fulfills the issue - https://github.com/NUKnightLab/TimelineJS3/issues/770

Previously a user, using arrow keys, could navigate outside of the available range of slides which was causing exceptions:

https://user-images.githubusercontent.com/68850090/176469635-c95923d8-8fda-4d20-97f9-45237b9f3ec7.mp4

Now with the incoming index validation, there will be no exceptions:

https://user-images.githubusercontent.com/68850090/176469754-65c456ce-0329-4f3c-903a-1431b5d4dd22.mp4


