### PR TITLE
Fix appearing of the `Slidenav` arrows on mobile

### DIFF
--- a/src/js/slider/StorySlider.js
+++ b/src/js/slider/StorySlider.js
@@ -326,7 +326,7 @@ export class StorySlider {
     showNav(nav_obj, show) {
 
         if (this.options.width <= 500 && Browser.mobile) {
-
+            nav_obj.hide();
         } else {
             if (show) {
                 nav_obj.show();

--- a/src/less/slider/TL.SlideNav.less
+++ b/src/less/slider/TL.SlideNav.less
@@ -219,20 +219,24 @@
             }
         }
     }
-	.tl-slidenav-previous:hover {
-		.tl-slidenav-icon {
-			//margin-left: 0px;
-			margin-left: 100 - 20px;
-			.opacity(100);
-		}
-	}
-	.tl-slidenav-previous:active {
-		.tl-slidenav-icon {
-		   .opacity(100);
-		   margin-left: -4px;
-		}
-	}
+    .tl-slidenav-previous {
+        &:hover {
+            /**
+            * On mobile the hover state stays on the button after the click
+            * Show the default margin as before the click
+            */
+            .tl-slidenav-icon {
+                margin-left: 0px;
+                .opacity(100);
+            }
+        }
 
+        &:active {
+            .tl-slidenav-icon {
+                margin-left: -4px;
+            }
+        }
+    }
 }
 
 .tl-layout-portrait.tl-mobile {

--- a/src/less/slider/TL.SlideNav.less
+++ b/src/less/slider/TL.SlideNav.less
@@ -201,20 +201,24 @@
 
 
 .tl-layout-landscape.tl-mobile {
-	.tl-slidenav-next:hover {
+    .tl-slidenav-next {
+        &:hover {
+            /**
+            * On mobile the hover state stays on the button after the click
+            * Show the default margin as before the click
+            */
+            .tl-slidenav-icon {
+                margin-left: 100 - 24px;
+                .opacity(100);
+            }
+        }
 
-		right: 70px;
-		.tl-slidenav-icon {
-	       margin-left:32 - 24px;
-		   .opacity(100);
-		}
-	}
-	.tl-slidenav-next:active {
-		.tl-slidenav-icon {
-			margin-left: 0px;
-		   .opacity(100);
-		}
-	}
+        &:active {
+            .tl-slidenav-icon {
+                margin-left: 100 - 20px;
+            }
+        }
+    }
 	.tl-slidenav-previous:hover {
 		.tl-slidenav-icon {
 			//margin-left: 0px;


### PR DESCRIPTION
## This PR fulfills the issue - https://github.com/NUKnightLab/TimelineJS3/issues/772

Previously the arrows were always on the screen when a user turns their phone to landscape mode for the first time. Now they will hide when the user has a viewport of less than 500px and he's using a mobile

---

Fixed randomly jumping sideways arrows in the landscape mode. Now their behavior matches
![Peek 2022-07-04 17-51](https://user-images.githubusercontent.com/68850090/177191832-e74c506c-b98d-4354-ab4b-ade4f4e3701c.gif)
 the desktop
![Peek 2022-07-04 17-59](https://user-images.githubusercontent.com/68850090/177191831-0aa27952-8ffa-4b8b-a941-1d35ab9fed8d.gif)



