### PR TITLE
Added `prepublishOnly` event script

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
         "start": "npx webpack serve --open --config webpack.dev.js",
         "stage": "npm run dist && node tasks/stage.js",
         "stage_latest": "npm run dist && node tasks/stage.js latest",
-        "stage_dev": "npm run dist && node tasks/stage.js dev"
+        "stage_dev": "npm run dist && node tasks/stage.js dev",
+        "prepublishOnly": "npm run dist"
     },
     "contributors": [
         {


### PR DESCRIPTION
It would be extremely convenient to have a script that will build the library before it'll be published to NPM. Because we already stumbled on the "we forgot to build the `dist` before" publishing a few times during the custom fork development